### PR TITLE
Create Super Street Fighter II X Stage Select Event Mode (Japan 94022…

### DIFF
--- a/release/_Arcade Offset/_CP System II/Super Street Fighter II X Stage Select Event Mode (Japan 940223).mra
+++ b/release/_Arcade Offset/_CP System II/Super Street Fighter II X Stage Select Event Mode (Japan 940223).mra
@@ -1,0 +1,119 @@
+<!--          FPGA arcade hardware by Jotego
+
+              This core is available for hardware compatible with MiST and MiSTer
+              Other FPGA systems may be supported by the time you read this.
+              This work is not mantained by the MiSTer project. Please contact the
+              core author for issues and updates.
+
+              (c) Jose Tejada, 2026. Please support this research
+              Patreon: https://patreon.com/jotego
+
+              The author does not endorse or participate in illegal distribution
+              of copyrighted material. This work can be used with compatible
+              software. This software can be homebrew projects or legally
+              obtained memory dumps of compatible games.
+
+              This file license is GNU GPLv2.
+              You can read the whole license file in
+              https://opensource.org/licenses/gpl-2.0.php
+
+	      Stage Select and Event Mode Hack by D.Owls
+
+-->
+
+<misterromdescription>
+    <about author="jotego" webpage="https://patreon.com/jotego" twitter="@topapate" source="https://jotego/jtcores"/>
+    <rotation>horizontal</rotation>
+    <name>Super Street Fighter II X: Grand Master Challenge (Japan 940223) [Stage Select + Event Mode]</name>
+    <setname>ssf2xjr1</setname>
+    <mameversion>0282</mameversion>
+    <year>1994</year>
+    <manufacturer>Capcom</manufacturer>
+    <players>2</players>
+    <rbf>jtcps2</rbf>
+    <joystick>8</joystick>
+    <region>World</region>
+    <rom index="0" zip="ssf2xjr1.zip|ssf2t.zip|qsound.zip" md5="None" address="0x30000000" asm_md5="49635257a7dbdfb0e6d4a0bafe301844">
+        <!--  -->
+        <part>
+            00 0E 00 0F 00 1F 00 5F
+            FF FF FF FF FF FF FF FF
+            32 FF 00 02 04 06 26 28
+            2A 2C 2E 00 00 30 02 04
+            08 30 FF FF FF FF FF FF
+            FC FF FF FF </part>
+        <!-- key - starts at 0x0 - length 0x14 (5 bits) -->
+        <part name="ssf2xj.key" crc="160d1424"/>
+        <!-- maincpu - starts at 0x14 - length 0x380000 (22 bits) -->
+        <part name="sfxj.03c" crc="a7417b79"/>
+        <part name="sfxj.04a" crc="af7767b4"/>
+        <part name="sfxj.05" crc="f4ff18f5"/>
+        <part name="sfxj.06a" crc="260d0370"/>
+        <part name="sfxj.07" crc="1324d02a"/>
+        <part name="sfxj.08" crc="2de76f10"/>
+        <part name="sfx.09" crc="642fae3f"/>
+        <!-- audiocpu - starts at 0x380014 - length 0x40000 (18 bits) -->
+        <part name="sfx.01" crc="b47b8835"/>
+        <part name="sfx.02" crc="0022633f"/>
+        <!-- qsound - starts at 0x3C0014 - length 0x400000 (22 bits) -->
+        <interleave output="16">
+            <part name="sfx.11m" crc="9bdbd476" map="12"/>
+        </interleave>
+        <interleave output="16">
+            <part name="sfx.12m" crc="a05e3aab" map="12"/>
+        </interleave>
+        <!-- gfx - starts at 0x7C0014 - length 0x1000000 (24 bits) -->
+        <interleave output="64">
+            <part name="sfx.13m" crc="cf94d275" map="00000021"/>
+            <part name="sfx.15m" crc="5eb703af" map="00002100"/>
+            <part name="sfx.17m" crc="ffa60e0f" map="00210000"/>
+            <part name="sfx.19m" crc="34e825c5" map="21000000"/>
+        </interleave>
+        <interleave output="64">
+            <part name="sfx.14m" crc="b7cc32e7" map="00000021"/>
+            <part name="sfx.16m" crc="8376ad18" map="00002100"/>
+            <part name="sfx.18m" crc="f5b1b336" map="00210000"/>
+            <part name="sfx.20m" crc="459d5c6b" map="21000000"/>
+        </interleave>
+        <interleave output="64">
+            <part name="sfx.21m" crc="e32854af" map="00000021"/>
+            <part name="sfx.23m" crc="760f2927" map="00002100"/>
+            <part name="sfx.25m" crc="1ee90208" map="00210000"/>
+            <part name="sfx.27m" crc="f814400f" map="21000000"/>
+        </interleave>
+        <!-- firmware - starts at 0x17C0014 - length 0x2000 (13 bits) -->
+        <part name="dl-1425.bin" crc="d6cf5ef5" length="0x2000"/>
+        <!-- Total 0x17C2014 bytes - 24328 kBytes -->
+            <!-- ssf2xj stage-select: COIN on char-select = highlighted characters stage (persistent). offset=CPU+0x40 -->
+        <patch offset="0x0039E6">97 c6 47 61 61 ef</patch>
+        <patch offset="0x00E9F8">b3 e1 f1 52 e2 1f</patch>
+        <patch offset="0x00FB26">e4 65 a1 7f 35 fe</patch>
+        <patch offset="0x00E066">8b d7 97 a9 8d 62</patch>
+        <patch offset="0x245840">58 a1 da 0b 3b d7 52 ae 73 04 cc b0 83 cd da 88 56 73 b3 f8 e0 af 11 64 17 9e c7 a3 78 a0 db bb a7 01 39 8a 5d ed b0 54 c4 b2 0b 2b c5 77 65 ab f3 61 37 ba 61 ad 80 23 84 dd 05 09 a1 a5 3a 7b ca a3 fa 37 c9 10 59 d2 6b a3 51 3d f8 8b 7d f7 b9 f8 dd d9 d8 55 85 41 53 eb c8 b7 c0 ab 6f 0b</patch>
+        <patch offset="0x2458C0">0d ce 32 eb ec 6b 28 c5 4b f4 9f 05 2b 89 84 ea 85 25 a5 81 c5 8b 5a 61 39 74 fe 00 0a 1f 1a 91 8f 94 ba 38 52 50 f5 b5 85 ad b2 08 a7 46 2d 62 b7 26 06 a8 b5 05 e2 75 db 6b 89 be e2 c0</patch>
+        <patch offset="0x245940">68 12 01 fb 3f 23 cc 51 49 3f 50 76 23 ce 10 b2 42 1b 0d e1 f9 c0 74 1f 77 36 e6 6e 21 60 de 62 f0 8a</patch>
+        <patch offset="0x245970">50 62 d9 63 b0 1b 64 3b 46 5e a3 b3 90 47 51 ca 28 a1 00 e6 bd 40 57 11</patch>
+    </rom>
+    <rom index="2">
+        <part>
+00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
+00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 01
+00 01 01 00 01 01 00 00 02 94 41 17 46 53 45 58
+00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
+00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 01
+00 01 01 00 01 01 00 00 02 94 41 17 46 53 45 58
+00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
+00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
+</part>
+    </rom>
+    <nvram index="2" size="128"/>
+    <rom index="1">
+        <part>00 80</part>
+    </rom>
+    <switches page_id="1" page_name="Switches" base="16" default="ff,ff">
+        <DSWA/>
+        <DSWB/>
+        <DSWC/>
+    </switches>
+    <buttons names="Light Punch,Middle Punch,Heavy Punch,Light Kick,Middle Kick,Heavy Kick,Start,Coin" default="A,B,X,Y,L,R,Start,Select,-" count="6"/>
+</misterromdescription>


### PR DESCRIPTION
This contains an MRA patch for Super Street Fighter II X (Japan 940223). 

It adds two things

1. Stage Select
     
This allows a player to select a state using the coin button. This requires a 2 player mode. If either player highlights a character and then presses their coin button, it will load their match on the stage of the characters they were highlighting when coin was pressed. The game will lock onto this stage until a new stage is manually selected or the game returns to a single player mode, at which point normal single player operation with return

2. Event Mode

This forces a game over and return to attract mode after every match. This is great for tournaments to avoid having to wait for a kill off when players swap out. To enable this, enter the service menu and set Continue to OFF. 

When continue is ON, the game will function as normal.
